### PR TITLE
Use locate-user-emacs-file

### DIFF
--- a/pomm.el
+++ b/pomm.el
@@ -87,7 +87,7 @@
   :type 'string)
 
 (defcustom pomm-state-file-location
-  (concat user-emacs-directory "pomm")
+  (locate-user-emacs-file "pomm")
   "Location of the pomm state file."
   :group 'pomm
   :type 'string)


### PR DESCRIPTION
The `locate-user-emacs-file` function is purpose built to find files like this.

I'd consider, as a note, changing the default filename to `pomm-state.el`, however.